### PR TITLE
Improve OTA verification and add defensive input validation

### DIFF
--- a/src/api/LocalServer.cpp
+++ b/src/api/LocalServer.cpp
@@ -20,18 +20,6 @@ static bool _rateLimited(unsigned long& lastMs) {
     return false;
 }
 
-// Simple rate limiter: track last request time per endpoint category
-static unsigned long _lastTriggerMs = 0;
-static unsigned long _lastConfigMs = 0;
-static const unsigned long RATE_LIMIT_MS = 1000;  // 1 request/second
-
-static bool _rateLimited(unsigned long& lastMs) {
-    unsigned long now = millis();
-    if (now - lastMs < RATE_LIMIT_MS) return true;
-    lastMs = now;
-    return false;
-}
-
 void LocalServer::begin(ConfigManager* config, AudioManager* audio,
                         PrayerScheduler* scheduler, NtpSync* ntp) {
     _config = config;

--- a/src/net/BackendClient.cpp
+++ b/src/net/BackendClient.cpp
@@ -140,14 +140,17 @@ bool BackendClient::sendHeartbeat() {
 
     // Check for sync triggers
     if (response.containsKey("syncTrigger") && _sync) {
-        int prayer = response["syncTrigger"]["prayer"];
-        unsigned long epoch = response["syncTrigger"]["triggerAtEpoch"];
-        _sync->setSyncTrigger(prayer, epoch);
+        int prayer = response["syncTrigger"]["prayer"] | -1;
+        unsigned long epoch = response["syncTrigger"]["triggerAtEpoch"] | 0UL;
+        if (prayer >= 0 && epoch > 0) {
+            _sync->setSyncTrigger(prayer, epoch);
+        }
     }
 
     // Check for pending commands
     if (response.containsKey("command")) {
-        const char* cmd = response["command"]["command"];
+        const char* cmd = response["command"]["command"] | "";
+        if (strlen(cmd) == 0) return true;
         Serial.printf("[Backend] Command received: %s\n", cmd);
 
         if (strcmp(cmd, "restart") == 0) {
@@ -235,7 +238,7 @@ bool BackendClient::_httpGet(const char* path, JsonDocument& response) {
     }
 
     int code = http.GET();
-    if (code != 200) {
+    if (code < 200 || code >= 300) {
         snprintf(_lastError, sizeof(_lastError), "GET %s → %d", path, code);
         Serial.printf("[Backend] %s\n", _lastError);
         http.end();

--- a/src/net/OfflineCache.cpp
+++ b/src/net/OfflineCache.cpp
@@ -97,5 +97,16 @@ int OfflineCache::cachedDayCount() {
 }
 
 String OfflineCache::_pathForDate(const char* dateKey) {
+    // Validate dateKey format: must be YYYY-MM-DD (10 chars)
+    if (!dateKey || strlen(dateKey) != 10) {
+        return String(CACHE_PATH) + "/invalid.json";
+    }
+    for (int i = 0; i < 10; i++) {
+        if (i == 4 || i == 7) {
+            if (dateKey[i] != '-') return String(CACHE_PATH) + "/invalid.json";
+        } else {
+            if (dateKey[i] < '0' || dateKey[i] > '9') return String(CACHE_PATH) + "/invalid.json";
+        }
+    }
     return String(CACHE_PATH) + "/" + dateKey + ".json";
 }

--- a/src/ota/OtaManager.cpp
+++ b/src/ota/OtaManager.cpp
@@ -8,6 +8,7 @@
 #include <Update.h>
 #include <esp_ota_ops.h>
 #include <Preferences.h>
+#include <mbedtls/sha256.h>
 
 int OtaManager::_consecutiveFailures = 0;
 
@@ -57,9 +58,9 @@ bool OtaManager::applyUpdate(const OtaUpdateInfo& info) {
     // Set LED to indicate update in progress
     if (_led) _led->setState(LedState::ERROR);  // Fast blink during OTA
 
-    // Download
+    // Download and verify SHA256
     _state = OtaState::DOWNLOADING;
-    if (!_download(info.url, info.size)) {
+    if (!_download(info.url, info.size, info.sha256)) {
         _consecutiveFailures++;
         _state = OtaState::ERROR;
 
@@ -68,11 +69,6 @@ bool OtaManager::applyUpdate(const OtaUpdateInfo& info) {
         }
         return false;
     }
-
-    // Verify SHA256
-    _state = OtaState::VERIFYING;
-    // Note: SHA256 verification happens during download via Update library
-    // The Update library handles partition writing and verification
 
     // Success
     _state = OtaState::REBOOTING;
@@ -85,7 +81,7 @@ bool OtaManager::applyUpdate(const OtaUpdateInfo& info) {
     return true;  // Never reached
 }
 
-bool OtaManager::_download(const char* url, int expectedSize) {
+bool OtaManager::_download(const char* url, int expectedSize, const char* expectedSha256) {
     HTTPClient http;
     http.begin(url);
     http.setTimeout(30000);  // 30s timeout
@@ -108,8 +104,10 @@ bool OtaManager::_download(const char* url, int expectedSize) {
         return false;
     }
 
-    // Enable MD5 checksum verification during write
-    Update.setMD5(nullptr);  // Reset — we'll verify SHA256 post-download
+    // Initialize SHA256 context for verification
+    mbedtls_sha256_context sha_ctx;
+    mbedtls_sha256_init(&sha_ctx);
+    mbedtls_sha256_starts(&sha_ctx, 0);  // 0 = SHA-256
 
     // Stream download directly to flash
     WiFiClient* stream = http.getStreamPtr();
@@ -127,9 +125,13 @@ bool OtaManager::_download(const char* url, int expectedSize) {
         int readBytes = stream->readBytes(buf, min(available, (int)sizeof(buf)));
         if (readBytes <= 0) break;
 
+        // Update SHA256 hash with downloaded data
+        mbedtls_sha256_update(&sha_ctx, buf, readBytes);
+
         int wroteNow = Update.write(buf, readBytes);
         if (wroteNow != readBytes) {
             snprintf(_error, sizeof(_error), "Write error at %d bytes", written);
+            mbedtls_sha256_free(&sha_ctx);
             Update.abort();
             http.end();
             return false;
@@ -145,6 +147,31 @@ bool OtaManager::_download(const char* url, int expectedSize) {
     }
 
     http.end();
+
+    // Verify SHA256 hash before finalizing
+    _state = OtaState::VERIFYING;
+    if (expectedSha256 && strlen(expectedSha256) == 64) {
+        uint8_t sha_result[32];
+        mbedtls_sha256_finish(&sha_ctx, sha_result);
+        mbedtls_sha256_free(&sha_ctx);
+
+        char computed[65];
+        for (int i = 0; i < 32; i++) {
+            sprintf(computed + i * 2, "%02x", sha_result[i]);
+        }
+        computed[64] = '\0';
+
+        if (strcmp(computed, expectedSha256) != 0) {
+            snprintf(_error, sizeof(_error), "SHA256 mismatch");
+            Serial.printf("[OTA] SHA256 mismatch!\n  Expected: %s\n  Computed: %s\n", expectedSha256, computed);
+            Update.abort();
+            return false;
+        }
+        Serial.println("[OTA] SHA256 verified OK");
+    } else {
+        mbedtls_sha256_free(&sha_ctx);
+        Serial.println("[OTA] No SHA256 provided, skipping verification");
+    }
 
     if (!Update.end(true)) {
         snprintf(_error, sizeof(_error), "Update.end failed: %s", Update.errorString());

--- a/src/ota/OtaManager.cpp
+++ b/src/ota/OtaManager.cpp
@@ -8,8 +8,7 @@
 #include <Update.h>
 #include <esp_ota_ops.h>
 #include <Preferences.h>
-#include <esp_system.h>
-#include <mbedtls/md.h>
+#include <mbedtls/sha256.h>
 
 int OtaManager::_consecutiveFailures = 0;
 
@@ -107,11 +106,10 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
 
     // Initialize SHA256 context for verification
     bool doVerify = (expectedSha256 && strlen(expectedSha256) == 64);
-    mbedtls_md_context_t md_ctx;
-    mbedtls_md_init(&md_ctx);
+    mbedtls_sha256_context sha_ctx;
     if (doVerify) {
-        mbedtls_md_setup(&md_ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 0);
-        mbedtls_md_starts(&md_ctx);
+        mbedtls_sha256_init(&sha_ctx);
+        mbedtls_sha256_starts(&sha_ctx, 0);
     }
 
     // Stream download directly to flash
@@ -130,15 +128,14 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
         int readBytes = stream->readBytes(buf, min(available, (int)sizeof(buf)));
         if (readBytes <= 0) break;
 
-        // Update SHA256 hash with downloaded data
         if (doVerify) {
-            mbedtls_md_update(&md_ctx, buf, readBytes);
+            mbedtls_sha256_update(&sha_ctx, buf, readBytes);
         }
 
         int wroteNow = Update.write(buf, readBytes);
         if (wroteNow != readBytes) {
             snprintf(_error, sizeof(_error), "Write error at %d bytes", written);
-            if (doVerify) mbedtls_md_free(&md_ctx);
+            if (doVerify) mbedtls_sha256_free(&sha_ctx);
             Update.abort();
             http.end();
             return false;
@@ -159,8 +156,8 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
     _state = OtaState::VERIFYING;
     if (doVerify) {
         uint8_t sha_result[32];
-        mbedtls_md_finish(&md_ctx, sha_result);
-        mbedtls_md_free(&md_ctx);
+        mbedtls_sha256_finish(&sha_ctx, sha_result);
+        mbedtls_sha256_free(&sha_ctx);
 
         char computed[65];
         for (int i = 0; i < 32; i++) {

--- a/src/ota/OtaManager.cpp
+++ b/src/ota/OtaManager.cpp
@@ -8,7 +8,8 @@
 #include <Update.h>
 #include <esp_ota_ops.h>
 #include <Preferences.h>
-#include <mbedtls/sha256.h>
+#include <esp_system.h>
+#include <mbedtls/md.h>
 
 int OtaManager::_consecutiveFailures = 0;
 
@@ -105,9 +106,13 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
     }
 
     // Initialize SHA256 context for verification
-    mbedtls_sha256_context sha_ctx;
-    mbedtls_sha256_init(&sha_ctx);
-    mbedtls_sha256_starts(&sha_ctx, 0);  // 0 = SHA-256
+    bool doVerify = (expectedSha256 && strlen(expectedSha256) == 64);
+    mbedtls_md_context_t md_ctx;
+    mbedtls_md_init(&md_ctx);
+    if (doVerify) {
+        mbedtls_md_setup(&md_ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 0);
+        mbedtls_md_starts(&md_ctx);
+    }
 
     // Stream download directly to flash
     WiFiClient* stream = http.getStreamPtr();
@@ -126,12 +131,14 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
         if (readBytes <= 0) break;
 
         // Update SHA256 hash with downloaded data
-        mbedtls_sha256_update(&sha_ctx, buf, readBytes);
+        if (doVerify) {
+            mbedtls_md_update(&md_ctx, buf, readBytes);
+        }
 
         int wroteNow = Update.write(buf, readBytes);
         if (wroteNow != readBytes) {
             snprintf(_error, sizeof(_error), "Write error at %d bytes", written);
-            mbedtls_sha256_free(&sha_ctx);
+            if (doVerify) mbedtls_md_free(&md_ctx);
             Update.abort();
             http.end();
             return false;
@@ -150,16 +157,15 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
 
     // Verify SHA256 hash before finalizing
     _state = OtaState::VERIFYING;
-    if (expectedSha256 && strlen(expectedSha256) == 64) {
+    if (doVerify) {
         uint8_t sha_result[32];
-        mbedtls_sha256_finish(&sha_ctx, sha_result);
-        mbedtls_sha256_free(&sha_ctx);
+        mbedtls_md_finish(&md_ctx, sha_result);
+        mbedtls_md_free(&md_ctx);
 
         char computed[65];
         for (int i = 0; i < 32; i++) {
-            sprintf(computed + i * 2, "%02x", sha_result[i]);
+            snprintf(computed + i * 2, 3, "%02x", sha_result[i]);
         }
-        computed[64] = '\0';
 
         if (strcmp(computed, expectedSha256) != 0) {
             snprintf(_error, sizeof(_error), "SHA256 mismatch");
@@ -169,7 +175,6 @@ bool OtaManager::_download(const char* url, int expectedSize, const char* expect
         }
         Serial.println("[OTA] SHA256 verified OK");
     } else {
-        mbedtls_sha256_free(&sha_ctx);
         Serial.println("[OTA] No SHA256 provided, skipping verification");
     }
 

--- a/src/ota/OtaManager.h
+++ b/src/ota/OtaManager.h
@@ -48,8 +48,7 @@ private:
     char _error[128] = "";
     bool _justUpdated = false;
 
-    bool _download(const char* url, int expectedSize);
-    bool _verifySha256(const char* expected);
+    bool _download(const char* url, int expectedSize, const char* expectedSha256 = nullptr);
     void _markBootSuccessful();
 
     static int _consecutiveFailures;

--- a/src/prayer/PrayerScheduler.cpp
+++ b/src/prayer/PrayerScheduler.cpp
@@ -126,7 +126,10 @@ void PrayerScheduler::_recalculate() {
     // Simple: just add 1 day (good enough for suhoor lookahead)
     struct tm t = _ntp->localTime();
     t.tm_mday += 1;
-    mktime(&t);  // Normalize
+    if (mktime(&t) == (time_t)-1) {
+        Serial.println("[Scheduler] mktime failed for tomorrow calculation");
+        return;
+    }
     _tomorrowTimes = _calculator.calculate(t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, lat, lon);
 
     char buf[6];


### PR DESCRIPTION
## Summary
This PR enhances the OTA update process with inline SHA256 verification and adds defensive input validation across multiple modules to prevent crashes from malformed or missing data.

## Key Changes

**OTA Manager (OtaManager.cpp/h)**
- Integrated SHA256 verification directly into the download stream using mbedtls instead of post-download verification
- SHA256 hash is now computed incrementally as data is downloaded, improving efficiency
- Verification happens before `Update.end()` is called, allowing early abort on mismatch
- Added proper cleanup of SHA256 context on error paths
- Removed separate `_verifySha256()` method; verification is now part of `_download()`
- Updated `_download()` signature to accept `expectedSha256` parameter

**Backend Client (BackendClient.cpp)**
- Added null-coalescing operators (`|`) for JSON field extraction to handle missing keys gracefully
- Added validation checks before using extracted values (prayer >= 0, epoch > 0, cmd length > 0)
- Changed HTTP status code check from exact `200` to range `200-299` to accept all success codes
- Prevents crashes when backend response is missing expected fields

**Local Server (LocalServer.cpp)**
- Removed duplicate rate limiter implementation (duplicate function definition)

**Offline Cache (OfflineCache.cpp)**
- Added strict validation of dateKey format in `_pathForDate()` to ensure YYYY-MM-DD format
- Validates length (10 chars), dash positions, and numeric digits
- Returns invalid path for malformed dates instead of potentially creating bad file paths

**Prayer Scheduler (PrayerScheduler.cpp)**
- Added error handling for `mktime()` failure when calculating tomorrow's prayer times
- Prevents undefined behavior if time normalization fails

## Implementation Details
- SHA256 verification now uses mbedtls library (already a dependency)
- Hash computation is streaming to minimize memory overhead
- All input validation uses early returns to fail safely
- Error messages are logged for debugging

https://claude.ai/code/session_01Gp7xJGdqMXKcCa99CgoBgA