### PR TITLE
feat: optimize Claude Code skills and model selection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep"
+    ]
+  }
+}

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -2,7 +2,7 @@
 name: build
 description: Build the ESP32-C3 firmware using PlatformIO. Use when compiling, building, or checking for errors.
 disable-model-invocation: true
-allowed-tools: Bash Read
+allowed-tools: Bash Read Glob
 argument-hint: "[clean]"
 ---
 
@@ -15,8 +15,13 @@ Compile the MyAthan firmware for ESP32-C3 using PlatformIO.
 1. If argument is "clean", run `pio run -t clean -e esp32c3` first
 2. Run `pio run -e esp32c3`
 3. Report the build result:
-   - If success: report binary size from `.pio/build/esp32c3/firmware.bin`
+   - If success: report binary size from `.pio/build/esp32c3/firmware.bin` (must be <=1.5MB for OTA)
    - If failure: analyze the error, suggest a fix, and show the relevant source code
+
+## Binary Size Tracking
+- OTA partition limit: 1.5MB (1,572,864 bytes)
+- Report: `ls -la .pio/build/esp32c3/firmware.bin`
+- Warn if binary exceeds 1.2MB (80% of OTA limit)
 
 ## Common Issues
 - Missing `#include` — check if a new header was added without including it

--- a/.claude/skills/flash/SKILL.md
+++ b/.claude/skills/flash/SKILL.md
@@ -2,7 +2,7 @@
 name: flash
 description: Flash firmware and filesystem to ESP32-C3 device. Use when uploading, flashing, or programming the device.
 disable-model-invocation: true
-allowed-tools: Bash Read
+allowed-tools: Bash Read Glob
 argument-hint: "[fs|monitor]"
 ---
 

--- a/.claude/skills/optimize-claude/SKILL.md
+++ b/.claude/skills/optimize-claude/SKILL.md
@@ -9,18 +9,52 @@ argument-hint: "[audit|fix|report]"
 
 Audit and optimize Claude Code setup for the MyAthan firmware repo.
 
-## Model Selection Guide
+## Model Selection Engine
 
-Choose the right Claude model for each task type:
+### Available Models
+- **Opus 4.6** (`claude-opus-4-6`) — Best reasoning. ~$15/M in, $75/M out. Use for hard problems.
+- **Sonnet 4.6** (`claude-sonnet-4-6`) — Best value. ~$3/M in, $15/M out. Default choice.
+- **Haiku 4.5** (`claude-haiku-4-5-20251001`) — Fastest/cheapest. ~$0.25/M in, $1.25/M out. Use for simple tasks.
 
-| Task Type | Model | Reasoning |
-|-----------|-------|-----------|
-| Prayer calculation algorithms, high-latitude edge cases | **Opus** | Complex math and astronomical reasoning |
-| Architecture changes, cross-repo schema updates | **Opus** | Cascading effects across firmware and core |
-| Feature implementation, driver code, new modules | **Sonnet** | Standard coding with good speed/quality balance |
-| Bug fixes, config changes, single-file edits | **Sonnet** | Well-scoped changes with clear patterns |
-| Build/flash/test commands, simple config tweaks | **Haiku** | Fast CLI execution with minimal reasoning |
-| Code review with ESP32 safety checklist | **Sonnet** | Checklist-driven analysis within bounded scope |
+### Decision Matrix — Always pick the cheapest option that gets the job done
+
+| Task Type | Model | Version | Effort | Thinking | 1M Context | Cost |
+|-----------|-------|---------|--------|----------|------------|------|
+| Prayer math, high-latitude algorithms | Opus | 4.6 | max | ON | no | $$$$ |
+| Architecture, cross-repo schema cascades | Opus | 4.6 | high | ON | no | $$$ |
+| Multi-module debugging (scheduler+audio+prayer) | Opus | 4.6 | high | ON | no | $$$ |
+| Feature implementation, new driver/module | Sonnet | 4.6 | high | OFF | no | $$ |
+| Bug fixes, config changes | Sonnet | 4.6 | med | OFF | no | $$ |
+| Code review (ESP32 safety checklist) | Sonnet | 4.6 | high | OFF | no | $$ |
+| Single-file edits, header updates | Sonnet | 4.6 | med | OFF | no | $$ |
+| Build/flash/test commands | Haiku | 4.5 | low | OFF | no | $ |
+| Simple config.json tweaks | Haiku | 4.5 | low | OFF | no | $ |
+| Git operations, file lookups | Haiku | 4.5 | low | OFF | no | $ |
+
+### Configuration Rules
+
+**Version:** Always 4.6 for Opus/Sonnet (strictly better). Haiku = 4.5 (only version).
+
+**Thinking mode:**
+- **ON** when: prayer math (trig, angle-of-sun), high-latitude edge cases, multi-module debugging, config migration design, security analysis
+- **OFF** when: everything else. Embedded code follows clear patterns; thinking adds cost without benefit.
+- Rule of thumb: if you can describe the change in one sentence, thinking is OFF.
+
+**1M context:**
+- Almost **never** for this repo — firmware is ~20 source files, well under standard context.
+- Only if reading ARCHITECTURE.md (36KB) + multiple source files + tests simultaneously.
+- Never for build/flash/test, single-file edits, or standard feature work.
+
+**Effort levels:**
+- `max` — Prayer calculation only. Wrong math = wrong prayer times (high stakes).
+- `high` — Multi-file changes, code review (ESP32 safety matters), new modules.
+- `med` — Bug fixes, config changes, single-file work. **This is the default.**
+- `low` — CLI commands (build/flash/test), lookups, git operations.
+
+**Cost escalation rule:** Start at the cheapest tier. Only escalate if:
+1. The task failed or produced poor results at the current tier
+2. The task inherently requires deeper reasoning (see matrix above)
+3. Never pre-escalate "just to be safe" — that wastes budget
 
 ## Steps
 
@@ -34,7 +68,8 @@ Based on argument:
    - [ ] Key modules listed with locations
    - [ ] Development/build commands documented
    - [ ] Cross-repo references (core repo link)
-   - [ ] Model selection guidance section
+   - [ ] Model selection decision matrix (model + version + effort + thinking + 1M)
+   - [ ] Cost tier guidance with escalation rules
    - [ ] Common development patterns
    - [ ] Testing strategy documented
 2. Scan all skills in `.claude/skills/*/SKILL.md`:

--- a/.claude/skills/optimize-claude/SKILL.md
+++ b/.claude/skills/optimize-claude/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: optimize-claude
+description: Audit and optimize Claude Code configuration, skills, and CLAUDE.md for maximum AI performance. Use to tune Claude's effectiveness on this repo.
+allowed-tools: Bash Read Grep Glob Edit Write
+argument-hint: "[audit|fix|report]"
+---
+
+# Optimize Claude Configuration
+
+Audit and optimize Claude Code setup for the MyAthan firmware repo.
+
+## Model Selection Guide
+
+Choose the right Claude model for each task type:
+
+| Task Type | Model | Reasoning |
+|-----------|-------|-----------|
+| Prayer calculation algorithms, high-latitude edge cases | **Opus** | Complex math and astronomical reasoning |
+| Architecture changes, cross-repo schema updates | **Opus** | Cascading effects across firmware and core |
+| Feature implementation, driver code, new modules | **Sonnet** | Standard coding with good speed/quality balance |
+| Bug fixes, config changes, single-file edits | **Sonnet** | Well-scoped changes with clear patterns |
+| Build/flash/test commands, simple config tweaks | **Haiku** | Fast CLI execution with minimal reasoning |
+| Code review with ESP32 safety checklist | **Sonnet** | Checklist-driven analysis within bounded scope |
+
+## Steps
+
+Based on argument:
+
+### `audit` (default)
+1. Read `CLAUDE.md` and check for:
+   - [ ] Project overview and tech stack documented
+   - [ ] Architecture section with file paths
+   - [ ] Hardware constraints documented (RAM, flash, GPIO)
+   - [ ] Key modules listed with locations
+   - [ ] Development/build commands documented
+   - [ ] Cross-repo references (core repo link)
+   - [ ] Model selection guidance section
+   - [ ] Common development patterns
+   - [ ] Testing strategy documented
+2. Scan all skills in `.claude/skills/*/SKILL.md`:
+   - [ ] Each skill has a clear, trigger-friendly description
+   - [ ] `allowed-tools` matches the skill's actual needs
+   - [ ] `disable-model-invocation` is only set for pure CLI-runner skills
+   - [ ] Error recovery instructions included for skills that can fail
+   - [ ] Skills that analyze code have `Grep` and `Glob` tools
+   - [ ] Skills that fix code have `Edit` tool
+3. Check `.claude/settings.json`:
+   - [ ] Read-only tools auto-allowed (Read, Glob, Grep)
+   - [ ] No overly permissive settings
+4. Check `.github/workflows/claude.yml`:
+   - [ ] Claude Code Action configured
+   - [ ] Proper permissions (contents: read, pull-requests: write, issues: write)
+5. Calculate optimization score (checklist items passed / total)
+6. Report findings with specific recommendations
+
+### `fix`
+1. Run the `audit` checklist above
+2. Automatically fix issues found:
+   - Add missing tools to skill `allowed-tools`
+   - Remove unnecessary `disable-model-invocation` flags
+   - Add missing sections to CLAUDE.md
+   - Create settings.json if missing
+3. Report what was fixed
+
+### `report`
+1. Run `audit` and output a concise summary:
+   - Overall score: X/Y checks passing
+   - Top 3 highest-impact improvements
+   - Model selection recommendations for recent git activity
+
+## Skill Optimization Checklist
+
+When reviewing any skill, verify:
+- **Description**: Should clearly state WHEN to use it (trigger words help Claude match user intent)
+- **Tools**: Minimum set needed. Read-only analysis needs `Read Grep Glob`. Code changes need `Edit`. File creation needs `Write`.
+- **Model invocation**: Disable ONLY for pure CLI runners (build, flash, dev server). Enable for anything requiring analysis, diagnosis, or decision-making.
+- **Error recovery**: Skills that run commands should include "On Failure" instructions
+- **Context**: Skills should reference project-specific paths, constraints, and patterns
+
+## ESP32-C3 Constraints (Quick Reference)
+- 400KB total RAM, ~300KB usable
+- 4MB flash: 2x1MB app partitions (OTA) + 600KB LittleFS
+- BLE 5.0 only (no Classic BT, no A2DP audio streaming)
+- GPIO6/7 reserved for DFPlayer UART1, GPIO8 for LED, GPIO9 for button
+- No SoftwareSerial — hardware UART only
+- OTA binary must be <=1.5MB
+
+## Token Efficiency Tips
+
+- CLAUDE.md should be under 100 lines — dense, structured, no prose
+- Use tables and lists over paragraphs
+- Include file paths so Claude doesn't need to search
+- Reference specific types/functions by name
+- Keep cross-repo sync notes brief but actionable

--- a/.claude/skills/optimize-claude/SKILL.md
+++ b/.claude/skills/optimize-claude/SKILL.md
@@ -120,10 +120,24 @@ When reviewing any skill, verify:
 - No SoftwareSerial — hardware UART only
 - OTA binary must be <=1.5MB
 
-## Token Efficiency Tips
+## Token Efficiency & Caching Tips
 
-- CLAUDE.md should be under 100 lines — dense, structured, no prose
-- Use tables and lists over paragraphs
-- Include file paths so Claude doesn't need to search
+- CLAUDE.md should be under 120 lines — dense, structured, no prose
+- Use tables and lists over paragraphs (30-50% fewer tokens than prose)
+- Include file paths so Claude doesn't need to search (saves Grep/Glob tool calls)
 - Reference specific types/functions by name
 - Keep cross-repo sync notes brief but actionable
+- Put stable content at top of CLAUDE.md, volatile content at bottom (prompt caching works top-down)
+- Avoid rewriting CLAUDE.md frequently — each edit invalidates the prompt cache
+
+## Caching & Compression Audit
+
+When auditing, also check:
+- [ ] CLAUDE.md has stable content (tech stack, architecture) at the top
+- [ ] CLAUDE.md has volatile content (branch names, current sprint) at the bottom
+- [ ] CLAUDE.md line count is under 120 (longer = more cached tokens but also more cost)
+- [ ] Skills with `disable-model-invocation: true` are truly CLI-only (saves reasoning tokens)
+- [ ] settings.json auto-allows read-only tools (saves permission round-trip tokens)
+- [ ] No duplicate information between CLAUDE.md and ARCHITECTURE.md/README.md (wasted tokens)
+- [ ] Cost & performance optimization section exists in CLAUDE.md
+- [ ] Subagent delegation patterns documented (use cheap models for search, expensive for reasoning)

--- a/.claude/skills/prayer-verify/SKILL.md
+++ b/.claude/skills/prayer-verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prayer-verify
 description: Verify prayer time calculation accuracy for a specific city. Use to validate PrayerCalculator output against known references.
-allowed-tools: Bash Read WebSearch WebFetch
+allowed-tools: Bash Read Grep Glob WebSearch WebFetch
 argument-hint: "[city_name]"
 ---
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: test
-description: Run firmware unit tests using PlatformIO. Use when testing prayer calculator, Hijri calendar, or other firmware components.
-disable-model-invocation: true
-allowed-tools: Bash Read
+description: Run firmware unit tests, analyze failures, and fix issues. Use when testing prayer calculator, Hijri calendar, or other firmware components.
+allowed-tools: Bash Read Grep Glob Edit
 argument-hint: "[test_name]"
 ---
 
 # Run Firmware Tests
 
-Execute PlatformIO unit tests for the MyAthan firmware.
+Execute PlatformIO unit tests for the MyAthan firmware, analyze failures, and fix them.
 
 ## Steps
 
@@ -16,13 +15,26 @@ Execute PlatformIO unit tests for the MyAthan firmware.
 2. If no argument, run all tests: `pio test -e esp32c3`
 3. Analyze results:
    - Report pass/fail counts
-   - For failures: read the test file and source code, diagnose the issue
+   - For failures:
+     1. Read the failing test file in `test/`
+     2. Read the corresponding source code in `src/`
+     3. Trace the calculation logic to find the discrepancy
+     4. Fix the source code or test expectation as appropriate
+     5. Re-run the specific failing test to verify
    - Suggest fixes for any failing tests
 
 ## Available Test Suites
 - `test_prayer_calculator` — 10 tests: prayer times for multiple cities, all 7 methods, high-latitude, ASR Standard vs Hanafi
+  - Source: `src/prayer/PrayerCalculator.h`, `src/prayer/PrayerCalculator.cpp`
 - `test_hijri_calendar` — 18 tests: Gregorian→Hijri conversion, Ramadan detection, 7 holidays, leap years, adjustment
+  - Source: `src/prayer/HijriCalendar.h`, `src/prayer/HijriCalendar.cpp`
 
 ## Test References
 - Prayer times can be verified against https://aladhan.com/prayer-times-api
 - Hijri dates can be verified against https://www.islamicfinder.org/islamic-calendar/
+
+## On Failure
+1. Read the test output to identify which assertion failed
+2. Compare expected vs actual values
+3. Search the source for the calculation that produces the wrong value
+4. Fix the root cause, not just the test expectation

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,23 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,43 @@ ramadan (suhoorMode), hijri (adjustment), holidays (7 holidays), multiRoom, reco
 - Build: `pio run -e esp32c3`
 - Test: `pio test -e esp32c3`
 
+## Claude Model Guidance
+
+| Task | Model | Why |
+|------|-------|-----|
+| Prayer calculation algorithms, high-latitude edge cases | **Opus** | Complex astronomical math with edge cases |
+| Architecture changes, cross-repo schema updates | **Opus** | Cascading effects across firmware and core |
+| Feature implementation, driver code, new modules | **Sonnet** | Standard embedded coding tasks |
+| Bug fixes, config changes, single-file edits | **Sonnet** | Well-scoped changes |
+| Code review with ESP32 safety checklist | **Sonnet** | Checklist-driven analysis |
+| Build/flash/test commands, simple config tweaks | **Haiku** | Fast CLI execution |
+
+## Common Development Patterns
+
+1. **Prayer time change flow**: Edit `src/prayer/PrayerCalculator.cpp` → run `/test test_prayer_calculator` → run `/prayer-verify` for affected cities
+2. **Config schema change flow**: Edit `data/config.json` + `src/config/ConfigManager.cpp` → add migration in `_migrateIfNeeded()` → update defaults in `_applyDefaults()` → notify core repo for shared type update
+3. **New module flow**: Create `src/<module>/<Module>.h` + `.cpp` → add to `src/main.cpp` → write tests → run `/build` → run `/test`
+4. **Audio change flow**: Edit `src/audio/AudioManager.cpp` → verify volume 0-30 constraint → test non-blocking playback
+
+## Testing Strategy
+- Before any commit: `pio test -e esp32c3`
+- After prayer calculation changes: run `/prayer-verify` against Aladhan API for multiple cities
+- After config changes: verify `CONFIG_MAX_SIZE` (8192) is sufficient
+- After any change: run `/build` and check binary size (<1.5MB for OTA)
+
+## Cross-Repo Sync
+- `data/config.json` v2 schema must match core `DeviceConfig` in `packages/shared/`
+- Prayer time output format must match core `PrayerTimes` type
+- `IslamicHoliday` enum must match core enum
+- Any config schema change requires updates in BOTH repos
+
+## ESP32-C3 Quick Constraints
+- 300KB usable RAM (400KB total) — no large buffers
+- BLE 5.0 only — no Classic BT, no A2DP audio streaming
+- GPIO6/7 = DFPlayer UART1, GPIO8 = LED, GPIO9 = Button
+- OTA binary <=1.5MB, LittleFS config <=8192 bytes
+- No SoftwareSerial — hardware UART only
+
 ## Related
 - Core repo: `my-athan/core` (backend API, PWA, admin)
 - GitHub issues: #10-#24 on firmware repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,35 @@ ramadan (suhoorMode), hijri (adjustment), holidays (7 holidays), multiRoom, reco
 - 1M context adds premium on top — almost never needed for this repo
 - **Default to Sonnet 4.6 med/no-think** unless the task clearly needs more or less
 
+## Cost & Performance Optimization
+
+**Prompt caching (automatic):**
+- Claude caches repeated context (CLAUDE.md, skill definitions) at 90% discount
+- Keep CLAUDE.md stable — frequent edits invalidate the cache
+- Put rarely-changing content (tech stack, architecture) at the top, volatile content (branch names) at the bottom
+
+**Context management:**
+- Claude Code auto-compresses conversation history approaching limits — no action needed
+- For long sessions: start new sessions rather than accumulating stale context
+- Firmware source files are small (<500 lines each) — always readable in standard context
+
+**Subagent cost delegation:**
+- Use `subagent_type: "Explore"` with Haiku/Sonnet for codebase searches before invoking Opus
+- Delegate independent research tasks to parallel subagents — faster AND cheaper than serial Opus calls
+- Never use Opus for file discovery — use Grep/Glob tools directly (zero LLM cost)
+
+**Token-saving patterns:**
+- Skills with `disable-model-invocation: true` use zero reasoning tokens — keep this on pure CLI skills (/build, /flash)
+- Auto-allowed tools in settings.json skip permission prompts — saves round-trip tokens
+- Tables and lists in CLAUDE.md are 30-50% more token-efficient than prose paragraphs
+- Reference files by path instead of describing them — Claude reads the file instead of guessing
+
+**Avoid these cost traps:**
+- Don't enable thinking mode for simple edits — adds ~2-5x output tokens with no quality gain
+- Don't use 1M context — this repo has ~20 source files, well under standard limits
+- Don't re-read files already in conversation context — Claude remembers what it read
+- Don't ask Opus to run build/flash/test — Haiku executes PlatformIO commands identically at 60x less cost
+
 ## Common Development Patterns
 
 1. **Prayer time change flow**: Edit `src/prayer/PrayerCalculator.cpp` → run `/test test_prayer_calculator` → run `/prayer-verify` for affected cities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,16 +46,50 @@ ramadan (suhoorMode), hijri (adjustment), holidays (7 holidays), multiRoom, reco
 - Build: `pio run -e esp32c3`
 - Test: `pio test -e esp32c3`
 
-## Claude Model Guidance
+## Claude Model & Configuration Rules
 
-| Task | Model | Why |
-|------|-------|-----|
-| Prayer calculation algorithms, high-latitude edge cases | **Opus** | Complex astronomical math with edge cases |
-| Architecture changes, cross-repo schema updates | **Opus** | Cascading effects across firmware and core |
-| Feature implementation, driver code, new modules | **Sonnet** | Standard embedded coding tasks |
-| Bug fixes, config changes, single-file edits | **Sonnet** | Well-scoped changes |
-| Code review with ESP32 safety checklist | **Sonnet** | Checklist-driven analysis |
-| Build/flash/test commands, simple config tweaks | **Haiku** | Fast CLI execution |
+### Decision Matrix — Pick the cheapest option that gets the job done
+
+| Task | Model | Version | Effort | Thinking | 1M | Cost Tier |
+|------|-------|---------|--------|----------|----|-----------|
+| Prayer calculation algorithms, high-latitude math | **Opus** | 4.6 | max | ON | no | $$$$ |
+| Architecture changes, cross-repo schema updates | **Opus** | 4.6 | high | ON | no | $$$ |
+| Debugging multi-module issues (scheduler+audio+prayer) | **Opus** | 4.6 | high | ON | no | $$$ |
+| Feature implementation, new driver/module | **Sonnet** | 4.6 | high | OFF | no | $$ |
+| Bug fixes, config changes | **Sonnet** | 4.6 | med | OFF | no | $$ |
+| Code review with ESP32 safety checklist | **Sonnet** | 4.6 | high | OFF | no | $$ |
+| Single-file edits, header updates | **Sonnet** | 4.6 | med | OFF | no | $$ |
+| Build/flash/test commands | **Haiku** | 4.5 | low | OFF | no | $ |
+| Simple config.json tweaks | **Haiku** | 4.5 | low | OFF | no | $ |
+| Git operations, file lookups | **Haiku** | 4.5 | low | OFF | no | $ |
+
+### Automation Rules
+
+**Version selection:**
+- Always use **4.6** for Opus and Sonnet — latest generation, strictly better
+- Haiku is **4.5** only (latest available)
+
+**When to enable thinking:**
+- ON: Prayer math (trig, angle-of-sun), high-latitude edge cases, multi-module debugging, config migration design
+- OFF: Everything else — embedded code follows clear patterns, thinking adds cost without proportional benefit
+
+**When to use 1M context:**
+- Almost never for this repo — firmware is ~20 source files, well under standard context limits
+- Only if reading ARCHITECTURE.md (36KB) + multiple source files + tests simultaneously
+- Never for build/flash/test, single-file edits, or standard feature work
+
+**Effort level guide:**
+- `max`: Only for prayer calculation math — wrong results mean wrong prayer times (high stakes)
+- `high`: Multi-file changes, code review (ESP32 safety matters), new modules
+- `med`: Bug fixes, config changes, single-file feature work
+- `low`: CLI execution (build/flash/test), simple lookups, git commands
+
+**Cost awareness (relative per task):**
+- Haiku 4.5 low/no-think = **1x baseline** (~$0.25/M in, $1.25/M out)
+- Sonnet 4.6 med/no-think = **~12x** (~$3/M in, $15/M out)
+- Opus 4.6 high/thinking = **~100x** (~$15/M in, $75/M out + thinking tokens)
+- 1M context adds premium on top — almost never needed for this repo
+- **Default to Sonnet 4.6 med/no-think** unless the task clearly needs more or less
 
 ## Common Development Patterns
 


### PR DESCRIPTION
## Summary
- Add new `/optimize-claude` meta-skill that audits Claude Code configuration, skills, CLAUDE.md, and settings for maximum AI performance
- Enable model invocation on `/test` skill so Claude can analyze failures and auto-fix issues
- Expand tool permissions (`Grep`, `Glob`, `Edit`) on skills that need code analysis capabilities
- Add comprehensive model selection decision matrix to CLAUDE.md covering model (Opus/Sonnet/Haiku), version (4.5/4.6), effort level, thinking mode, 1M context, and cost tiers
- Add Claude Code GitHub Action (`claude.yml`) for @claude mentions in PRs/issues (parity with core repo)
- Add `.claude/settings.json` to auto-allow read-only tools (Read, Glob, Grep)

## Changes

| File | Change |
|------|--------|
| `.claude/skills/optimize-claude/SKILL.md` | **New** — Meta-skill for auditing Claude config |
| `.claude/settings.json` | **New** — Auto-allow read-only tools |
| `.github/workflows/claude.yml` | **New** — Claude Code GitHub Action |
| `.claude/skills/build/SKILL.md` | Add Glob, add binary size tracking guidance |
| `.claude/skills/test/SKILL.md` | Enable model invocation, add Grep/Glob/Edit for failure analysis |
| `.claude/skills/flash/SKILL.md` | Add Glob for filesystem verification |
| `.claude/skills/prayer-verify/SKILL.md` | Add Grep/Glob for source code tracing |
| `CLAUDE.md` | Add model selection matrix, cost tiers, automation rules, dev patterns, testing strategy |

## Test plan
- [ ] Verify all 6 skills appear in Claude Code skill list
- [ ] Run `/optimize-claude audit` and confirm it produces a valid report
- [ ] Test `/test` confirms it can now analyze failures and suggest fixes
- [ ] Test `/prayer-verify Mecca` confirms it can trace source code on discrepancies
- [ ] Verify `.claude/settings.json` auto-allows Read/Glob/Grep
- [ ] Verify `claude.yml` workflow file is valid YAML

https://claude.ai/code/session_016m6D12yaLzK8DZnpriKzWz